### PR TITLE
Fix java.util.Date parameter handling in DBContext

### DIFF
--- a/src/main/java/db/DBContext.java
+++ b/src/main/java/db/DBContext.java
@@ -75,7 +75,8 @@ public abstract class DBContext<T extends Entity, K extends KeyAttribute> {
                 } else if (param instanceof java.sql.Timestamp) {
                     stm.setTimestamp(i + 1, (java.sql.Timestamp) param);
                 } else if (param instanceof java.util.Date) {
-                    stm.setTimestamp(i + 1, (java.sql.Timestamp) param);
+                    java.util.Date utilDate = (java.util.Date) param;
+                    stm.setTimestamp(i + 1, new java.sql.Timestamp(utilDate.getTime()));
                 } else {
                     throw new SQLException("Unsupported parameter type: " + param.getClass().getName());
                 }


### PR DESCRIPTION
## Summary
- convert `java.util.Date` parameters to `java.sql.Timestamp` in `DBContext`

## Testing
- `mvn -q -e test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ab40d93a3083298772ca8d3aa86315