### PR TITLE
Fix resource controller naming

### DIFF
--- a/src/main/java/controller/file/ResourceFileReaderController.java
+++ b/src/main/java/controller/file/ResourceFileReaderController.java
@@ -43,7 +43,7 @@ public class ResourceFileReaderController extends FileReaderController {
         key.setId(resourceid);
         Resource resource = db.get(key);
         if(resource ==null)
-            throw new CustomException("Resouce does not exist!");
+            throw new CustomException("Resource does not exist!");
         ServletContext cntx= request.getServletContext();
         String filePath = cntx.getRealPath("file/resource/" + resource.getFile_url());
         serveFile(request, response, filePath, ALLOWED_FILE_TYPES);

--- a/src/main/java/controller/resource/DetailResourceController.java
+++ b/src/main/java/controller/resource/DetailResourceController.java
@@ -7,7 +7,6 @@ package controller.resource;
 
 import db.ResourceDBContext;
 import java.io.IOException;
-import java.io.PrintWriter;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
@@ -20,7 +19,7 @@ import util.base.CustomException;
  *
  * @author sonng
  */
-public class DetailResouceController extends HttpServlet {
+public class DetailResourceController extends HttpServlet {
    
     /** 
      * Processes requests for both HTTP <code>GET</code> and <code>POST</code> methods.
@@ -37,7 +36,7 @@ public class DetailResouceController extends HttpServlet {
         key.setId(resourceid);
         Resource resource = db.get(key);
         if(resource ==null)
-            throw new CustomException("Resouce does not exist!");
+            throw new CustomException("Resource does not exist!");
         
         
         request.setAttribute("resource", resource);

--- a/src/main/java/controller/resource/EditResourceController.java
+++ b/src/main/java/controller/resource/EditResourceController.java
@@ -49,7 +49,7 @@ public class EditResourceController extends HttpServlet {
         key.setId(resourceid);
         Resource resource = db.get(key);
         if(resource ==null)
-            throw new CustomException("Resouce does not exist!");
+            throw new CustomException("Resource does not exist!");
         request.setAttribute("resource", resource);
         
         UserDBContext udb = new UserDBContext();
@@ -76,7 +76,7 @@ public class EditResourceController extends HttpServlet {
         key_fromdb.setId(id);
         Resource resource_fromdb = db.get(key_fromdb);
         if(resource_fromdb ==null)
-            throw new CustomException("Resouce does not exist!");
+            throw new CustomException("Resource does not exist!");
         
         String name = request.getParameter("name");
         Resource resource = new Resource();

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -90,8 +90,8 @@
         <servlet-class>controller.resource.CreateResourceController</servlet-class>
     </servlet>
     <servlet>
-        <servlet-name>DetailResouceController</servlet-name>
-        <servlet-class>controller.resource.DetailResouceController</servlet-class>
+        <servlet-name>DetailResourceController</servlet-name>
+        <servlet-class>controller.resource.DetailResourceController</servlet-class>
     </servlet>
     <servlet>
         <servlet-name>ListResourceController</servlet-name>
@@ -186,7 +186,7 @@
         <url-pattern>/resource/create</url-pattern>
     </servlet-mapping>
     <servlet-mapping>
-        <servlet-name>DetailResouceController</servlet-name>
+        <servlet-name>DetailResourceController</servlet-name>
         <url-pattern>/resource/detail</url-pattern>
     </servlet-mapping>
     <servlet-mapping>


### PR DESCRIPTION
## Summary
- rename mis-typed DetailResouceController to DetailResourceController
- correct 'Resouce' misspellings in resource-related controllers
- update web.xml mappings to match new controller name

## Testing
- `mvn -q -e test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ab42481bcc8329a2af8998d495600b