### PR TITLE
Document string length validation and refine error message

### DIFF
--- a/src/main/java/util/controller/ValidationHelper.java
+++ b/src/main/java/util/controller/ValidationHelper.java
@@ -9,9 +9,24 @@ package util.controller;
  * @author sonng
  */
 public class ValidationHelper {
+
+    /**
+     * Validates that the provided {@code input} has a length between the given
+     * {@code minLength} and {@code maxLength}.
+     *
+     * <p>A {@code null} input triggers an {@link IllegalArgumentException}. The
+     * boundaries are inclusive, meaning an input length equal to
+     * {@code minLength} or {@code maxLength} is considered valid.</p>
+     *
+     * @param input the string to validate
+     * @param minLength the minimum acceptable length (inclusive)
+     * @param maxLength the maximum acceptable length (inclusive)
+     * @return {@code true} if the input length is within the specified bounds
+     * @throws IllegalArgumentException if {@code input} is {@code null}
+     */
     public static boolean validateStringLength(String input, int minLength, int maxLength) {
         if (input == null) {
-            throw new IllegalArgumentException("Length of inpu does not meet the requirement!");
+            throw new IllegalArgumentException("Input length does not meet the requirement!");
         }
         return input.length() >= minLength && input.length() <= maxLength;
     }


### PR DESCRIPTION
## Summary
- add Javadoc for `validateStringLength` clarifying null input handling and boundary inclusivity
- update exception text to "Input length does not meet the requirement!"

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: The following artifacts could not be resolved: org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 (absent): Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ab424b12348329bb3fe0f259547f20