### PR TITLE
Add ValidationHelper unit tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,18 @@
             <artifactId>jakarta.mail</artifactId>
             <version>2.0.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     
     <build>
@@ -66,6 +78,11 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
                 <version>3.3.2</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
             </plugin>
         </plugins>
     </build>

--- a/src/test/java/util/controller/ValidationHelperTest.java
+++ b/src/test/java/util/controller/ValidationHelperTest.java
@@ -1,0 +1,21 @@
+package util.controller;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ValidationHelperTest {
+    @Test
+    public void testValidStringWithinRangeReturnsTrue() {
+        assertTrue(ValidationHelper.validateStringLength("hello", 1, 10));
+    }
+
+    @Test
+    public void testStringOutsideRangeReturnsFalse() {
+        assertFalse(ValidationHelper.validateStringLength("this string is too long", 1, 5));
+    }
+
+    @Test
+    public void testNullInputThrowsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> ValidationHelper.validateStringLength(null, 1, 5));
+    }
+}


### PR DESCRIPTION
## Summary
- add JUnit tests for ValidationHelper.validateStringLength covering valid, invalid, and null inputs
- configure Maven with JUnit Jupiter and Surefire for running tests

## Testing
- `mvn -q test` *(fails: PluginResolutionException: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ab424c50b48329b6d3d8ebb39d7d89